### PR TITLE
Analog filter is now ON by default, to promote this block working out-of-the-box

### DIFF
--- a/grc/limesdr_source.xml
+++ b/grc/limesdr_source.xml
@@ -286,7 +286,7 @@
     <param>
         <name>CH0:Analog filter</name>
         <key>analog_filter_ch0</key>
-        <value>0</value>
+        <value>1</value>
         <type>enum</type>
         <hide>
 	  #if $file_switch() == 1
@@ -452,7 +452,7 @@
     <param>
         <name>CH1:Analog filter</name>
         <key>analog_filter_ch1</key>
-        <value>0</value>
+        <value>1</value>
         <type>enum</type>
         <hide>
 	  #if $chip_mode() == 1


### PR DESCRIPTION
If you want this block to work for people out-of-the-box, the analog filter should probably be enabled, because if they leave both filters off then they are going to see really low signal quality, and possibly not even see anything distinguishable at all.  Just a suggestion.