### PR TITLE
Add return statement to LimeSuite Sink

### DIFF
--- a/lib/sink_impl.cc
+++ b/lib/sink_impl.cc
@@ -284,6 +284,7 @@ namespace gr
 	    consume(0,ret0);
 	    consume(1,ret1);
 	}
+    return 0;
     }
 
     // Setup stream


### PR DESCRIPTION
The missing return statement doesn't seem to always cause problems but with certain configurations it forces the block and flow graph to stop completely.