### PR TITLE
Fixed bug in calling close_device where when a device was opened then…

### DIFF
--- a/lib/common/device_handler.cc
+++ b/lib/common/device_handler.cc
@@ -157,18 +157,15 @@ void device_handler::close_device(int device_number, int block_type)
     } 
   }
   // If two blocks used switch one block flag and let other block finish work
-  else
+  // Switch flag when closing device
+  switch(block_type)
   {
-    // Switch flag when closing device
-    switch(block_type)
-    {
-      case 1:
-	device_vector[device_number].source_flag = false;
-	break;
-      case 2:
-	device_vector[device_number].sink_flag = false;
-	break;
-    }     
+    case 1:
+      device_vector[device_number].source_flag = false;
+      break;
+    case 2:
+      device_vector[device_number].sink_flag = false;
+      break;
   }
 }
 


### PR DESCRIPTION
When calling  device_handler::close_device() the device_vector[device_number].source_flag or sink_flag were not getting set to false, so trying to open a new instance caused a error when testing the flag during device_handler::open_device(). Example code to reproduce the issue is in the comments. Sorry for the dupe.