### PR TITLE
Destroy LMS stream on flow-graph stop

### DIFF
--- a/lib/sink_impl.cc
+++ b/lib/sink_impl.cc
@@ -127,12 +127,12 @@ bool sink_impl::stop(void) {
     std::unique_lock<std::recursive_mutex> lock(device_handler::getInstance().block_mutex);
     // Stop stream for channel 0 (if channel_mode is SISO)
     if (stored.channel_mode < 2) {
-        LMS_StopStream(&streamId[stored.channel_mode]);
+        this->release_stream(stored.device_number, &streamId[stored.channel_mode]);
     }
     // Stop streams for channels 0 & 1 (if channel_mode is MIMO)
     else if (stored.channel_mode == 2) {
-        LMS_StopStream(&streamId[LMS_CH_0]);
-        LMS_StopStream(&streamId[LMS_CH_1]);
+        this->release_stream(stored.device_number, &streamId[LMS_CH_0]);
+        this->release_stream(stored.device_number, &streamId[LMS_CH_1]);
     }
     std::unique_lock<std::recursive_mutex> unlock(device_handler::getInstance().block_mutex);
     device_handler::getInstance().close_device(stored.device_number, sink_block);
@@ -269,6 +269,11 @@ void sink_impl::init_stream(int device_number, int channel) {
 
     std::cout << "INFO: sink_impl::init_stream(): sink channel " << channel << " (device nr. "
               << device_number << ") stream setup done." << std::endl;
+}
+
+void sink_impl::release_stream(int device_number, lms_stream_t *stream) {
+    LMS_StopStream(stream);
+    LMS_DestroyStream(device_handler::getInstance().get_device(device_number), stream);
 }
 
 // Return io_signature to manage module input count

--- a/lib/sink_impl.h
+++ b/lib/sink_impl.h
@@ -76,6 +76,7 @@ class sink_impl : public sink {
     inline gr::io_signature::sptr args_to_io_signature(int channel_number);
 
     void init_stream(int device_number, int channel);
+    void release_stream(int device_number, lms_stream_t *stream);
 
     double set_center_freq(double freq, size_t chan = 0);
 

--- a/lib/source_impl.cc
+++ b/lib/source_impl.cc
@@ -125,12 +125,12 @@ bool source_impl::stop(void) {
     std::unique_lock<std::recursive_mutex> lock(device_handler::getInstance().block_mutex);
     // Stop stream for channel 0 (if channel_mode is SISO)
     if (stored.channel_mode < 2) {
-        LMS_StopStream(&streamId[stored.channel_mode]);
+        this->release_stream(stored.device_number, &streamId[stored.channel_mode]);
     }
     // Stop streams for channels 0 & 1 (if channel_mode is MIMO)
     else if (stored.channel_mode == 2) {
-        LMS_StopStream(&streamId[LMS_CH_0]);
-        LMS_StopStream(&streamId[LMS_CH_1]);
+        this->release_stream(stored.device_number, &streamId[LMS_CH_0]);
+        this->release_stream(stored.device_number, &streamId[LMS_CH_1]);
     }
     std::unique_lock<std::recursive_mutex> unlock(device_handler::getInstance().block_mutex);
     device_handler::getInstance().close_device(stored.device_number, source_block);
@@ -218,6 +218,11 @@ void source_impl::init_stream(int device_number, int channel) {
 
     std::cout << "INFO: source_impl::init_stream(): source channel " << channel << " (device nr. "
               << device_number << ") stream setup done." << std::endl;
+}
+
+void source_impl::release_stream(int device_number, lms_stream_t *stream) {
+    LMS_StopStream(stream);
+    LMS_DestroyStream(device_handler::getInstance().get_device(device_number), stream);
 }
 
 // Print stream status

--- a/lib/source_impl.h
+++ b/lib/source_impl.h
@@ -70,6 +70,7 @@ class source_impl : public source {
     inline gr::io_signature::sptr args_to_io_signature(int channel_mode);
 
     void init_stream(int device_number, int channel);
+    void release_stream(int device_number, lms_stream_t *stream);
 
     double set_center_freq(double freq, size_t chan = 0);
 


### PR DESCRIPTION
Otherwise, as soon as the flow-graph is started again,
the following error message followed by segfault would
appear: "Setup Stream: Channel already in use".