### PR TITLE
Fix build on Python 2.7

### DIFF
--- a/docs/doxygen/doxyxml/text.py
+++ b/docs/doxygen/doxyxml/text.py
@@ -28,7 +28,7 @@ def is_string(txt):
     if isinstance(txt, str):
         return True
     try:
-        if isinstance(txt, str):
+        if isinstance(txt, unicode):
             return True
     except NameError:
         pass


### PR DESCRIPTION
Previously the gr-3.8 branch failed to build with "Expecting a string or something with content, content_ or value attribute"; this is because something was overzealous in its 2to3 conversion.