### PR TITLE
Add write_lms_reg() method to source and sink

### DIFF
--- a/include/limesdr/sink.h
+++ b/include/limesdr/sink.h
@@ -154,6 +154,16 @@ public:
      * @param   dacVal		   DAC value (0-65535)
      */
     virtual void set_tcxo_dac(uint16_t dacVal = 125) = 0;
+
+    /**
+     * Write LMS register
+     *
+     * Writes a parameter by calling LMS_WriteLMSReg()
+     *
+     * @param   address		   Address
+     * @param   val                Value
+     */
+    virtual void write_lms_reg(uint32_t address, uint16_t val) = 0;
 };
 } // namespace limesdr
 } // namespace gr

--- a/include/limesdr/source.h
+++ b/include/limesdr/source.h
@@ -163,6 +163,16 @@ public:
      * @param   dacVal		   DAC value (0-65535)
      */
     virtual void set_tcxo_dac(uint16_t dacVal = 125) = 0;
+
+    /**
+     * Write LMS register
+     *
+     * Writes a parameter by calling LMS_WriteLMSReg()
+     *
+     * @param   address		   Address
+     * @param   val                Value
+     */
+    virtual void write_lms_reg(uint32_t address, uint16_t val) = 0;
 };
 
 } // namespace limesdr

--- a/lib/device_handler.cc
+++ b/lib/device_handler.cc
@@ -647,3 +647,7 @@ void device_handler::update_rfe_channels()
             << std::endl;
     }
 }
+
+void device_handler::write_lms_reg(int device_number, uint32_t address, uint16_t val) {
+    LMS_WriteLMSReg(device_handler::getInstance().get_device(device_number), address, val);    
+}

--- a/lib/device_handler.cc
+++ b/lib/device_handler.cc
@@ -540,8 +540,8 @@ device_handler::set_gain(int device_number, bool direction, int channel, unsigne
                   << gain_value << " dB." << std::endl;
         return gain_value;
     } else {
-        std::cout
-            << "ERROR: device_handler::set_gain(): valid range [0, 73]" << std::endl;
+        std::cout << "ERROR: device_handler::set_gain(): valid range [0, 73]"
+                  << std::endl;
         close_all_devices();
     }
 }
@@ -648,6 +648,8 @@ void device_handler::update_rfe_channels()
     }
 }
 
-void device_handler::write_lms_reg(int device_number, uint32_t address, uint16_t val) {
-    LMS_WriteLMSReg(device_handler::getInstance().get_device(device_number), address, val);    
+void device_handler::write_lms_reg(int device_number, uint32_t address, uint16_t val)
+{
+    LMS_WriteLMSReg(
+        device_handler::getInstance().get_device(device_number), address, val);
 }

--- a/lib/device_handler.h
+++ b/lib/device_handler.h
@@ -321,6 +321,11 @@ public:
      * Assigns configured LimeSDR channels to LimeRFE for automatic channel switching
      */
     void update_rfe_channels();
+
+    /**
+     * Writes an LMS register by calling LMS_WriteLMSReg()
+     */
+    void write_lms_reg(int device_number, uint32_t address, uint16_t val);
 };
 
 

--- a/lib/device_handler.h
+++ b/lib/device_handler.h
@@ -61,13 +61,12 @@ private:
         std::string sink_filename;
     };
 
-    struct rfe_device
-    {
+    struct rfe_device {
         int rx_channel = 0;
         int tx_channel = 0;
         rfe_dev_t* rfe_dev = nullptr;
-    }rfe_device;
-    
+    } rfe_device;
+
 
     // Device list
     lms_info_str_t* list = new lms_info_str_t[20];
@@ -313,7 +312,8 @@ public:
      */
     void set_tcxo_dac(int device_number, uint16_t dacVal);
     /**
-     * Sets up LimeRFE device pointer so that automatic channel configuration could be made
+     * Sets up LimeRFE device pointer so that automatic channel configuration could be
+     * made
      * @param   rfe_dev  Pointer to LimeRFE device descriptor
      */
     void set_rfe_device(rfe_dev_t* rfe_dev);

--- a/lib/sink_impl.cc
+++ b/lib/sink_impl.cc
@@ -396,5 +396,10 @@ void sink_impl::set_tcxo_dac(uint16_t dacVal)
     device_handler::getInstance().set_tcxo_dac(stored.device_number, dacVal);
 }
 
+void sink_impl::write_lms_reg(uint32_t address, uint16_t val)
+{
+    device_handler::getInstance().write_lms_reg(stored.device_number, address, val);
+}
+  
 } // namespace limesdr
 } // namespace gr

--- a/lib/sink_impl.cc
+++ b/lib/sink_impl.cc
@@ -400,6 +400,6 @@ void sink_impl::write_lms_reg(uint32_t address, uint16_t val)
 {
     device_handler::getInstance().write_lms_reg(stored.device_number, address, val);
 }
-  
+
 } // namespace limesdr
 } // namespace gr

--- a/lib/sink_impl.h
+++ b/lib/sink_impl.h
@@ -101,6 +101,8 @@ public:
     void calibrate(double bandw, int channel = 0);
 
     void set_tcxo_dac(uint16_t dacVal = 125);
+
+    void write_lms_reg(uint32_t address, uint16_t val);
 };
 } // namespace limesdr
 } // namespace gr

--- a/lib/source_impl.cc
+++ b/lib/source_impl.cc
@@ -367,5 +367,10 @@ void source_impl::set_tcxo_dac(uint16_t dacVal)
     device_handler::getInstance().set_tcxo_dac(stored.device_number, dacVal);
 }
 
+void source_impl::write_lms_reg(uint32_t address, uint16_t val)
+{
+    device_handler::getInstance().write_lms_reg(stored.device_number, address, val);
+}
+  
 } /* namespace limesdr */
 } /* namespace gr */

--- a/lib/source_impl.cc
+++ b/lib/source_impl.cc
@@ -371,6 +371,6 @@ void source_impl::write_lms_reg(uint32_t address, uint16_t val)
 {
     device_handler::getInstance().write_lms_reg(stored.device_number, address, val);
 }
-  
+
 } /* namespace limesdr */
 } /* namespace gr */

--- a/lib/source_impl.h
+++ b/lib/source_impl.h
@@ -95,6 +95,8 @@ public:
     void calibrate(double bandw, int channel = 0);
 
     void set_tcxo_dac(uint16_t dacVal = 125);
+
+    void write_lms_reg(uint32_t address, uint16_t val);
 };
 
 } // namespace limesdr


### PR DESCRIPTION
This method calls LMS_WriteLMSReg() and gives a way of setting
LMS7002M registers directly from GNU Radio (for instance by
calling the method from Python)