### PR TITLE
Add MIMO phase align option

### DIFF
--- a/grc/limesdr_source.block.yml
+++ b/grc/limesdr_source.block.yml
@@ -45,6 +45,14 @@ parameters:
   default: 0
   category: General
 
+- id: ch_align
+  label: MIMO phase align
+  dtype: enum
+  options:       ['False', 'True']
+  option_labels: ['Disabled', 'Enabled']
+  default: 0
+  category: General
+
 - id: nco_freq_ch0
   label: NCO frequency
   dtype: float
@@ -152,7 +160,7 @@ parameters:
 templates:
   imports: import limesdr
   make: |-
-    limesdr.source(${serial}, ${channel_mode}, ${filename})
+    limesdr.source(${serial}, ${channel_mode}, ${filename}, ${ch_align})
 
     % if filename() == "":
 
@@ -313,6 +321,11 @@ documentation: |-
   Here you can select oversampling value for RX. Default value uses highest possible oversampling value.
   
   Note: LimeSDR-Mini and LimeSDR-Micro supports only the same oversampling value for TX and RX.
+  -------------------------------------------------------------------------------------------------------------------
+  MIMO PHASE ALIGN
+  
+  This enables or disables a calibration that aligns the phases of channels A and B as described in
+  https://github.com/myriadrf/LMS7002M-docs/blob/master/LimeSDR-USB_channel_alignment_v01r00.pdf
   -------------------------------------------------------------------------------------------------------------------
   NCO FREQUENCY
   

--- a/include/limesdr/source.h
+++ b/include/limesdr/source.h
@@ -50,9 +50,14 @@ public:
      *
      * @param filename Path to file if file switch is turned on.
      *
+     * @param align_ch_phase Perform MIMO phase alignment by calling AlignRxRF()
+     * as described in
+     * https://github.com/myriadrf/LMS7002M-docs/blob/master/LimeSDR-USB_channel_alignment_v01r00.pdf
+     *
      * @return a new limesdr source block object
      */
-    static sptr make(std::string serial, int channel_mode, const std::string& filename);
+    static sptr make(std::string serial, int channel_mode, const std::string& filename,
+		     bool align_ch_phase);
 
     /**
      * Set center frequency

--- a/include/limesdr/source.h
+++ b/include/limesdr/source.h
@@ -56,8 +56,10 @@ public:
      *
      * @return a new limesdr source block object
      */
-    static sptr make(std::string serial, int channel_mode, const std::string& filename,
-		     bool align_ch_phase);
+    static sptr make(std::string serial,
+                     int channel_mode,
+                     const std::string& filename,
+                     bool align_ch_phase);
 
     /**
      * Set center frequency

--- a/lib/source_impl.cc
+++ b/lib/source_impl.cc
@@ -28,12 +28,13 @@
 namespace gr {
 namespace limesdr {
 
-source::sptr
-source::make(std::string serial, int channel_mode, const std::string& filename,
-	     bool align_ch_phase)
+source::sptr source::make(std::string serial,
+                          int channel_mode,
+                          const std::string& filename,
+                          bool align_ch_phase)
 {
-    return gnuradio::get_initial_sptr(new source_impl(serial, channel_mode, filename,
-						      align_ch_phase));
+    return gnuradio::get_initial_sptr(
+        new source_impl(serial, channel_mode, filename, align_ch_phase));
 }
 
 /*
@@ -45,7 +46,7 @@ source::make(std::string serial, int channel_mode, const std::string& filename,
 source_impl::source_impl(std::string serial,
                          int channel_mode,
                          const std::string& filename,
-			 bool align_ch_phase)
+                         bool align_ch_phase)
     : gr::sync_block(
           "source", gr::io_signature::make(0, 0, 0), args_to_io_signature(channel_mode))
 {

--- a/lib/source_impl.h
+++ b/lib/source_impl.h
@@ -48,6 +48,7 @@ private:
         int channel_mode;
         double samp_rate = 10e6;
         uint32_t FIFO_size = 0;
+        int align;
     } stored;
 
     std::chrono::high_resolution_clock::time_point t1, t2;
@@ -57,7 +58,8 @@ private:
     void add_time_tag(int channel, lms_stream_meta_t meta);
 
 public:
-    source_impl(std::string serial, int channel_mode, const std::string& filename);
+    source_impl(std::string serial, int channel_mode, const std::string& filename,
+		bool align_ch_phase);
     ~source_impl();
 
     bool start(void);

--- a/lib/source_impl.h
+++ b/lib/source_impl.h
@@ -58,8 +58,10 @@ private:
     void add_time_tag(int channel, lms_stream_meta_t meta);
 
 public:
-    source_impl(std::string serial, int channel_mode, const std::string& filename,
-		bool align_ch_phase);
+    source_impl(std::string serial,
+                int channel_mode,
+                const std::string& filename,
+                bool align_ch_phase);
     ~source_impl();
 
     bool start(void);


### PR DESCRIPTION
This adds an option to the LimeSDR source to enable MIMO channel
phase alignment as described in

https://github.com/myriadrf/LMS7002M-docs/blob/master/LimeSDR-USB_channel_alignment_v01r00.pdf