### PR TITLE
Remove silent exception when importing Swig

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -24,12 +24,4 @@ description here (python/__init__.py).
 '''
 from __future__ import unicode_literals
 
-# import swig generated symbols into the limesdr namespace
-try:
-    # this might fail if the module is python-only
-    from .limesdr_swig import *
-except ImportError:
-    pass
-
-# import any pure python here
-#
+from .limesdr_swig import *


### PR DESCRIPTION
This PR removes the silent exception handling when importing the Python SWIG module. That is not ideal because it will obfuscate the real error leading to an [inefficient](https://github.com/myriadrf/gr-limesdr/search?q=AttributeError%3A+module&type=issues) error reporting experience. The silent exception is just recommended for pure Python modules.