### PR TITLE
Python Class GPIO Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Package includes GNU Radio blocks for various LimeSDR boards.
 
+## Fork Modifications
+
+Included support for LimeSDR GPIOs in the python sink and source classes.
+
 ## Documentation
 
 * [MyriadRF Wiki page](https://wiki.myriadrf.org/Gr-limesdr_Plugin_for_GNURadio)
@@ -17,15 +21,6 @@ Package includes GNU Radio blocks for various LimeSDR boards.
 
 * Installing GNURadio
 To install GNURadio3.8 please follow this guide [Installing GNURadio](https://wiki.gnuradio.org/index.php/InstallingGR)
-
-* Installing via PPA
-Only available for Ubuntu 20.04
-<pre>
-sudo add-apt-repository -y ppa:myriadrf/drivers
-sudo add-apt-repository -y ppa:myriadrf/gnuradio
-sudo apt update
-sudo apt install gr-limesdr
-</pre>
 
 * Building from source
 <pre>

--- a/include/limesdr/sink.h
+++ b/include/limesdr/sink.h
@@ -164,6 +164,33 @@ public:
      * @param   val                Value
      */
     virtual void write_lms_reg(uint32_t address, uint16_t val) = 0;
+
+    /**
+     * Set GPIO direction
+     *
+     * Set GPIO direction by calling LMS_GPIODirWrite()
+     *
+     * @param   dir        Direction bitmap (eight bits, one for each pin, 1 = output, 0 = input)
+     */
+    virtual void set_gpio_dir(uint8_t dir) = 0;
+
+    /**
+     * Write GPIO outputs
+     *
+     * Write GPIO outputs by calling LMS_GPIOWrite()
+     *
+     * @param   out        Level bitmap (eight bits, one for each pin)
+     */
+    virtual void write_gpio(uint8_t out) = 0;
+
+    /**
+     * Read GPIO inputs
+     *
+     * Read GPIO inputs by calling LMS_GPIORead()
+     *
+     * @return input level bitmap (eight bits, one for each pin)
+     */
+    virtual uint8_t read_gpio() = 0;
 };
 } // namespace limesdr
 } // namespace gr

--- a/include/limesdr/source.h
+++ b/include/limesdr/source.h
@@ -180,6 +180,33 @@ public:
      * @param   val                Value
      */
     virtual void write_lms_reg(uint32_t address, uint16_t val) = 0;
+
+    /**
+     * Set GPIO direction
+     *
+     * Set GPIO direction by calling LMS_GPIODirWrite()
+     *
+     * @param   dir        Direction bitmap (eight bits, one for each pin, 1 = output, 0 = input)
+     */
+    virtual void set_gpio_dir(uint8_t dir) = 0;
+
+    /**
+     * Write GPIO outputs
+     *
+     * Write GPIO outputs by calling LMS_GPIOWrite()
+     *
+     * @param   out        Level bitmap (eight bits, one for each pin)
+     */
+    virtual void write_gpio(uint8_t out) = 0;
+
+    /**
+     * Read GPIO inputs
+     *
+     * Read GPIO inputs by calling LMS_GPIORead()
+     *
+     * @return input level bitmap (eight bits, one for each pin)
+     */
+    virtual uint8_t read_gpio() = 0;
 };
 
 } // namespace limesdr

--- a/lib/device_handler.cc
+++ b/lib/device_handler.cc
@@ -653,3 +653,22 @@ void device_handler::write_lms_reg(int device_number, uint32_t address, uint16_t
     LMS_WriteLMSReg(
         device_handler::getInstance().get_device(device_number), address, val);
 }
+
+void device_handler::set_gpio_dir(int device_number, uint8_t dir)
+{
+  LMS_GPIODirWrite(device_handler::getInstance().get_device(device_number), &dir, 1);
+}
+
+void device_handler::write_gpio(int device_number, uint8_t out)
+{
+  LMS_GPIOWrite(device_handler::getInstance().get_device(device_number), &out, 1);
+}
+
+uint8_t device_handler::read_gpio(int device_number)
+{
+  uint8_t res;
+
+  LMS_GPIORead(device_handler::getInstance().get_device(device_number), &res, 1); 
+
+  return res;
+}

--- a/lib/device_handler.h
+++ b/lib/device_handler.h
@@ -326,6 +326,15 @@ public:
      * Writes an LMS register by calling LMS_WriteLMSReg()
      */
     void write_lms_reg(int device_number, uint32_t address, uint16_t val);
+
+    // Set GPIO pin directions, one bit per pin
+    void set_gpio_dir(int device_number, uint8_t dir);
+
+    // Write GPIO outputs, one bit per pin
+    void write_gpio(int device_number, uint8_t out);
+
+    // Read GPIO inputs, one bit per pin
+    uint8_t read_gpio(int device_number);
 };
 
 

--- a/lib/sink_impl.cc
+++ b/lib/sink_impl.cc
@@ -401,5 +401,20 @@ void sink_impl::write_lms_reg(uint32_t address, uint16_t val)
     device_handler::getInstance().write_lms_reg(stored.device_number, address, val);
 }
 
+void sink_impl::set_gpio_dir(uint8_t dir) 
+{
+    device_handler::getInstance().set_gpio_dir(stored.device_number, dir);
+}
+
+void sink_impl::write_gpio(uint8_t out) 
+{
+    device_handler::getInstance().write_gpio(stored.device_number, out);
+}
+
+uint8_t sink_impl::read_gpio() 
+{
+    return device_handler::getInstance().read_gpio(stored.device_number);
+}
+
 } // namespace limesdr
 } // namespace gr

--- a/lib/sink_impl.h
+++ b/lib/sink_impl.h
@@ -103,6 +103,15 @@ public:
     void set_tcxo_dac(uint16_t dacVal = 125);
 
     void write_lms_reg(uint32_t address, uint16_t val);
+
+    // Set GPIO pin directions, one bit per pin
+    void set_gpio_dir(uint8_t dir);
+
+    // Write GPIO outputs, one bit per pin
+    void write_gpio(uint8_t out);
+
+    // Read GPIO inputs, one bit per pin
+    uint8_t read_gpio();
 };
 } // namespace limesdr
 } // namespace gr

--- a/lib/source_impl.cc
+++ b/lib/source_impl.cc
@@ -377,5 +377,20 @@ void source_impl::write_lms_reg(uint32_t address, uint16_t val)
     device_handler::getInstance().write_lms_reg(stored.device_number, address, val);
 }
 
+void source_impl::set_gpio_dir(uint8_t dir) 
+{
+    device_handler::getInstance().set_gpio_dir(stored.device_number, dir);
+}
+
+void source_impl::write_gpio(uint8_t out) 
+{
+    device_handler::getInstance().write_gpio(stored.device_number, out);
+}
+
+uint8_t source_impl::read_gpio() 
+{
+    return device_handler::getInstance().read_gpio(stored.device_number);
+}
+
 } /* namespace limesdr */
 } /* namespace gr */

--- a/lib/source_impl.h
+++ b/lib/source_impl.h
@@ -101,6 +101,15 @@ public:
     void set_tcxo_dac(uint16_t dacVal = 125);
 
     void write_lms_reg(uint32_t address, uint16_t val);
+    
+    // Set GPIO pin directions, one bit per pin
+    void set_gpio_dir(uint8_t dir);
+
+    // Write GPIO outputs, one bit per pin
+    void write_gpio(uint8_t out);
+
+    // Read GPIO inputs, one bit per pin
+    uint8_t read_gpio();
 };
 
 } // namespace limesdr


### PR DESCRIPTION
Hi, I added LimeSDR GPIO Support to the GR plugin and therefore to the python classes. 
I required this functionality, maybe others would want it too.